### PR TITLE
Fix some issues for Nurve in-house use

### DIFF
--- a/lib/ruby-swagger/grape/type.rb
+++ b/lib/ruby-swagger/grape/type.rb
@@ -60,9 +60,7 @@ module Swagger::Grape
       match = @type.downcase.match(/\[(.*?)\]/)
       @swagger_type = {
         'type' => 'array',
-        'items' => {
-          'type' => match[1]
-        }
+        'items' => basic_type_schemes[match[1].downcase]
       }
     end
 

--- a/lib/ruby-swagger/grape/type.rb
+++ b/lib/ruby-swagger/grape/type.rb
@@ -94,7 +94,7 @@ module Swagger::Grape
           'format' => 'float'
         },
         'rack::multipart::uploadedfile' => {
-          'type' => 'string' # 'Warning - I have no idea how to handle the type file. Right now I will consider this a string, but we should probably handle it...'
+          'type' => 'file'
         },
         'date' => {
           'type' => 'string',

--- a/spec/swagger/grape/application_api.rb
+++ b/spec/swagger/grape/application_api.rb
@@ -177,6 +177,21 @@ class ApplicationsAPI < Grape::API
       api_present(@attributes)
     end
 
+    api_desc 'Uplaod image.' do
+      headers authentication_headers
+      scopes %w(application:read application:write)
+      tags %w(applications upload swag more_swag)
+      response StatusDetailed, isArray: true, headers: result_headers
+      api_name 'upload_image'
+    end
+    params do
+      requires :id, :type => String, :desc => "ID."
+      requires :image, :type => Rack::Multipart::UploadedFile, :desc => "Image file."
+    end
+    post '/:id/upload' do
+      new_file = ActionDispatch::Http::UploadedFile.new(params[:image])
+    end
+
     # Mix in with desc instead of api_desc
     desc 'Uninstall / unsubscribe an application by its unique id or by its code name.'
     delete '/:id' do

--- a/spec/swagger/grape/application_api.rb
+++ b/spec/swagger/grape/application_api.rb
@@ -6,6 +6,7 @@ require_relative '../grape/entities/error_redirect_entity'
 require_relative '../grape/entities/error_not_found_entity'
 require_relative '../grape/entities/error_boom_entity'
 require_relative '../grape/entities/detailed_status_entity'
+require_relative '../grape/entities/array_of_hash'
 
 class ApplicationsAPI < Grape::API
   version 'v1'
@@ -159,6 +160,21 @@ class ApplicationsAPI < Grape::API
     put '/:id' do
       @application = { id: '123456', name: 'An app', description: 'Great App' }
       api_present(@applications)
+    end
+
+    api_desc 'Fatch attributes.' do
+      headers authentication_headers
+      scopes %w(application:read)
+      tags %w(applications)
+      response ArrayOfHash, isArray: false, headers: result_headers
+      api_name 'get_attributes'
+    end
+    params do
+      requires :id, type: String, desc: 'Unique identifier or code name of the application'
+    end
+    get '/:id/attributes' do
+      @attributes = {attributes: {"a" => "b", "c" => "d"}}
+      api_present(@attributes)
     end
 
     # Mix in with desc instead of api_desc

--- a/spec/swagger/grape/entities/array_of_hash.rb
+++ b/spec/swagger/grape/entities/array_of_hash.rb
@@ -1,0 +1,5 @@
+require 'grape-entity'
+
+class ArrayOfHash < Grape::Entity
+  expose(:attributes, documentation: { type: 'Array[Hash]', desc: 'Attributes' })
+end

--- a/spec/swagger/integration_spec.rb
+++ b/spec/swagger/integration_spec.rb
@@ -458,6 +458,21 @@ describe 'Ruby::Swagger' do
                               'updated_at' => { 'type' => 'string' } } }
                          )
       end
+
+      it 'should create a definition file ArrayOfObject.yml' do
+        doc = open_yaml('./doc/swagger/definitions/ArrayOfHash.yml')
+
+        expect(doc).to eq({ 'type' => 'object',
+                            'properties' => {
+                              'attributes' => {
+                                'type' => 'array',
+                                'items' => {
+                                  'type' => 'object',
+                                  'properties' => {}
+                                },
+                                'description' => 'Attributes' } } }
+                          )
+      end
     end
   end
 end

--- a/spec/swagger/integration_spec.rb
+++ b/spec/swagger/integration_spec.rb
@@ -285,6 +285,52 @@ describe 'Ruby::Swagger' do
         expect(doc['parameters'][0]['type']).to eq 'string'
         expect(doc['parameters'][0]['required']).to be_truthy
       end
+
+      it 'should get parameters for application/{id}/upload/post.yml' do
+        doc = open_yaml('./doc/swagger/paths/applications/{id}/upload/post.yml')
+
+        expect(doc['parameters'].count).to eq 3
+
+        expect(doc['parameters'][2]['name']).to eq 'image'
+        expect(doc['parameters'][2]['in']).to eq 'formData'
+        expect(doc['parameters'][2]['description']).to eq 'Image file.'
+        expect(doc['parameters'][2]['type']).to eq 'file'
+        expect(doc['parameters'][2]['required']).to be_truthy
+      end
+    end
+
+    describe 'consumes' do
+      it 'should not get consumes for applications/{id}/check_access/get.yml' do
+        doc = open_yaml('./doc/swagger/paths/applications/{id}/check_access/get.yml')
+
+        expect(doc['consumes']).to be_nil
+      end
+
+      it 'should not get consumes for applications/get.yml' do
+        doc = open_yaml('./doc/swagger/paths/applications/get.yml')
+
+        expect(doc['consumes']).to be_nil
+      end
+
+      it 'should not get consumes for applications/post.yml' do
+        doc = open_yaml('./doc/swagger/paths/applications/{id}/post.yml')
+
+        expect(doc['consumes']).to be_nil
+      end
+
+      it 'should not get consumes for applications/{id}/delete.yml' do
+        doc = open_yaml('./doc/swagger/paths/applications/{id}/delete.yml')
+
+        expect(doc['consumes']).to be_nil
+      end
+
+      it 'should get consumes for application/{id}/upload/post.yml' do
+        doc = open_yaml('./doc/swagger/paths/applications/{id}/upload/post.yml')
+
+        expect(doc['consumes']).not_to be_nil
+        expect(doc['consumes'].count).to eq 1
+        expect(doc['consumes'][0]).to eq 'multipart/form-data'
+      end
     end
 
     describe 'response' do


### PR DESCRIPTION
- Convert an inner type of an array using type schemes defined in type.rb
- Support Rack::Multipart::UploadedFile properly. 
  - put parameters in formData instead of body when file type is in parameters.
  - set the proper MIME-type for the formData.
